### PR TITLE
[FIX] 최고관리자 담당자/고객 전체 조회시 유저 검색가능하도록 수정

### DIFF
--- a/src/controller/managerController.ts
+++ b/src/controller/managerController.ts
@@ -185,8 +185,9 @@ const getOwnerById = async (req: Request, res: Response) => {
 
 // 최고관리자 고객 정보 전체 조회
 const getAllCustomer = async (req: Request, res: Response) => {
+  const customerName = req.body.customerName;
   try {
-    const data = await managerService.getAllCustomer();
+    const data = await managerService.getAllCustomer(customerName);
     if (!data) {
       return res
         .status(sc.NOT_FOUND)

--- a/src/service/managerService.ts
+++ b/src/service/managerService.ts
@@ -75,7 +75,7 @@ const findManagerById = async (id: number) => {
 const getAllOwner = async (sort: string, ownerName: string) => {
   if (sort === "all") {
     const data = await prisma.store_Owner.findMany();
-    if (ownerName !== null) {
+    if (ownerName) {
       const data = await prisma.store_Owner.findMany({
         where: {
           director: { contains: ownerName },
@@ -94,7 +94,7 @@ const getAllOwner = async (sort: string, ownerName: string) => {
             authorized: true,
           },
         });
-        if (ownerName !== null) {
+        if (ownerName) {
           const data = await prisma.store_Owner.findMany({
             where: {
               director: { contains: ownerName },
@@ -110,7 +110,7 @@ const getAllOwner = async (sort: string, ownerName: string) => {
             authorized: false,
           },
         });
-        if (ownerName !== null) {
+        if (ownerName) {
           const data = await prisma.store_Owner.findMany({
             where: {
               director: { contains: ownerName },
@@ -135,8 +135,18 @@ const getOwnerById = async (ownerId: number) => {
 };
 
 // 최고관리자 고객 정보 전체 조회
-const getAllCustomer = async () => {
+const getAllCustomer = async (customerName: string) => {
   const data = await prisma.customer.findMany();
+
+  if (customerName) {
+    const data = await prisma.customer.findMany({
+      where: {
+        name: { contains: customerName },
+      },
+    });
+    return data;
+  }
+
   return data;
 };
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #51 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
- 최고관리자 마이페이지에서 담당자/고객정보를 전체 조회할 때에 검색어에 따라 담당자와 고객을 조회할 수 있도록 수정했습니다.

